### PR TITLE
Fix handling of logical types in schema

### DIFF
--- a/src/main/java/at/grahsl/kafka/connect/mongodb/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/converter/AvroJsonSchemafulRecordConverter.java
@@ -41,7 +41,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         );
 
     private final Map<Schema.Type, SinkFieldConverter> converters = new HashMap<>();
-    private final Map<Schema.Type, SinkFieldConverter> logicalConverters = new HashMap<>();
+    private final Map<String, SinkFieldConverter> logicalConverters = new HashMap<>();
 
     public AvroJsonSchemafulRecordConverter() {
 
@@ -79,7 +79,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private void registerSinkFieldLogicalConverter(SinkFieldConverter converter) {
-        logicalConverters.put(converter.getSchema().type(), converter);
+        logicalConverters.put(converter.getSchema().name(), converter);
     }
 
     private BsonDocument toBsonDoc(Schema schema, Object value) {
@@ -159,7 +159,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         SinkFieldConverter converter;
 
         if(isSupportedLogicalType(schema)) {
-            converter = logicalConverters.get(schema.type());
+            converter = logicalConverters.get(schema.name());
         } else {
             converter = converters.get(schema.type());
         }


### PR DESCRIPTION
Hi @hpgrahsl 

Great work on this connector!

I noticed that in the existing code, both the Date and Time logical types are being processed by the TimeFieldConverter

That is because the logicalConverters map was based on the schema.type and multiple logical types may have the same schema.type
For example, both the Date and Time schema.type is INT32

Fixing this issue in this commit