### PR TITLE
debezium CDC mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ value.converter.schemas.enable=true
 ### Post Processors
 Right after the conversion, the BSON documents undergo a **chain of post processors**. There are the following 4 processors to choose from:
 
-* **DocumentIdAdder** (mandatory): uses the configured _strategy_ (see above) to insert an **_id field**
+* **DocumentIdAdder** (mandatory): uses the configured _strategy_ (explained below) to insert an **_id field**
 * **BlacklistProjector** (optional): applicable for _key_ + _value_ structure
 * **WhitelistProjector** (optional): applicable for _key_ + _value_ structure
 * **FieldRenamer** (optional): applicable for _key_ + _value_ structure
@@ -354,12 +354,19 @@ These settings cause:
 Note the use of the **"." character** as navigational operator in both examples. It's used in order to refer to nested fields in sub documents of the record structure. The prefix at the very beginning is used as a simple convention to distinguish between the _key_ and _value_ structure of a document.
 
 ### Change Data Capture Mode
-The sink connector can also be used in a different operation mode in order to handle change data capture (CDC) events. Currently, the supported CDC events format used by the [Debezium MongoDB Source Connector](http://debezium.io/docs/connectors/mongodb/) can be processed. This effectively would allow to replicate all state changes in MongoDB collections over Apache Kafka. Further Debezium formats - namely MySQL and PostgreSQL - will probably get integrated in future releases in order to replicate CDC events into MongoDB which originate from RDBMS.
+The sink connector can also be used in a different operation mode in order to handle change data capture (CDC) events. Currently, the following CDC events from [Debezium](http://debezium.io/) can be processed:
+
+* [MongoDB](http://debezium.io/docs/connectors/mongodb/) 
+* [MySQL](http://debezium.io/docs/connectors/mysql/)
+* PostgreSQL (coming later)
+* Oracle (not yet finished at Debezium Project)
+
+This effectively allows to replicate all state changes within the source databases into MongoDB collections. Further Debezium formats - namely PostgreSQL and Oracle - will probably get integrated in future releases.
  
 Also note that **both serialization formats (JSON+Schema & AVRO) can be used** depending on which configuration is a better fit for your use case.
 
 ##### CDC Handler Configuration
-The sink connector configuration offers a property called *mongodb.change.data.capture.handler* which is set to the fully qualified class name of the respective CDC format handler class. These classes must extend from the provided abstract class *[CdcHandler](https://github.com/hpgrahsl/kafka-connect-mongodb/blob/master/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/CdcHandler.java)*. As soon as this configuration property is set the connector runs in **CDC operation mode**. Find below a JSON based configuration sample for the sink connector which uses the current default implementation that is capable to process Debezium CDC MongoDB events. This config can be posted to the Kafka connect REST endpoint in order to run the sink connector.
+The sink connector configuration offers a property called *mongodb.change.data.capture.handler* which is set to the fully qualified class name of the respective CDC format handler class. These classes must extend from the provided abstract class *[CdcHandler](https://github.com/hpgrahsl/kafka-connect-mongodb/blob/master/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/CdcHandler.java)*. As soon as this configuration property is set the connector runs in **CDC operation mode**. Find below a JSON based configuration sample for the sink connector which uses the current default implementation that is capable to process Debezium CDC MongoDB events. This config can be posted to the [Kafka connect REST endpoint](https://docs.confluent.io/current/connect/restapi.html) in order to run the sink connector.
 
 ```json
 {
@@ -372,7 +379,7 @@ The sink connector configuration offers a property called *mongodb.change.data.c
   	"connector.class": "at.grahsl.kafka.connect.mongodb.MongoDbSinkConnector",
     "topics": "myreplset.kafkaconnect.mongosrc",
     "mongodb.connection.uri": "mongodb://mongodb:27017/kafkaconnect?w=1&journal=true",
-    "mongodb.change.data.capture.handler": "at.grahsl.kafka.connect.mongodb.cdc.debezium.mongodb.MongoDbHandlerHandler",
+    "mongodb.change.data.capture.handler": "at.grahsl.kafka.connect.mongodb.cdc.debezium.mongodb.MongoDbHandler",
     "mongodb.collection": "mongosink"
   }
 }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
@@ -18,6 +18,7 @@ package at.grahsl.kafka.connect.mongodb;
 
 import at.grahsl.kafka.connect.mongodb.cdc.CdcHandler;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.mongodb.MongoDbHandler;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql.MysqlHandler;
 import at.grahsl.kafka.connect.mongodb.processor.*;
 import at.grahsl.kafka.connect.mongodb.processor.field.projection.FieldProjector;
 import at.grahsl.kafka.connect.mongodb.processor.field.renaming.FieldnameMapping;
@@ -302,6 +303,7 @@ public class MongoDbSinkConnectorConfig extends AbstractConfig {
     public static Set<String> getPredefinedCdcHandlerClassNames() {
         Set<String> cdcHandlers = new HashSet<String>();
         cdcHandlers.add(MongoDbHandler.class.getName());
+        cdcHandlers.add(MysqlHandler.class.getName());
         return cdcHandlers;
     }
 

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTask.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTask.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class MongoDbSinkTask extends SinkTask {
 
@@ -166,7 +167,7 @@ public class MongoDbSinkTask extends SinkTask {
         return records.stream()
                 .map(sinkConverter::convert)
                 .map(cdcHandler::handle)
-                .filter(Objects::nonNull)
+                .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
                 .collect(Collectors.toList());
 
     }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/CdcHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/CdcHandler.java
@@ -21,6 +21,8 @@ import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
 import com.mongodb.client.model.WriteModel;
 import org.bson.BsonDocument;
 
+import java.util.Optional;
+
 public abstract class CdcHandler {
 
     private final MongoDbSinkConnectorConfig config;
@@ -33,6 +35,6 @@ public abstract class CdcHandler {
         return this.config;
     }
 
-    public abstract WriteModel<BsonDocument> handle(SinkDocument doc);
+    public abstract Optional<WriteModel<BsonDocument>> handle(SinkDocument doc);
 
 }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/DebeziumCdcHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/DebeziumCdcHandler.java
@@ -19,8 +19,6 @@ package at.grahsl.kafka.connect.mongodb.cdc.debezium;
 import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
 import at.grahsl.kafka.connect.mongodb.cdc.CdcHandler;
 import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
-import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
-import com.mongodb.client.model.WriteModel;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonDocument;
 
@@ -43,6 +41,10 @@ public abstract class DebeziumCdcHandler extends CdcHandler {
 
     public CdcOperation getCdcOperation(BsonDocument doc) {
         try {
+            if(!doc.containsKey(OPERATION_TYPE_FIELD_PATH)
+                    || !doc.get(OPERATION_TYPE_FIELD_PATH).isString()) {
+                throw new DataException("error: value doc is missing CDC operation type of type string");
+            }
             CdcOperation op = operations.get(OperationType.fromText(
                     doc.get(OPERATION_TYPE_FIELD_PATH).asString().getValue())
             );
@@ -55,7 +57,5 @@ public abstract class DebeziumCdcHandler extends CdcHandler {
             throw new DataException("error: parsing CDC operation failed",exc);
         }
     }
-
-    public abstract WriteModel<BsonDocument> handle(SinkDocument doc);
 
 }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/DebeziumCdcHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/DebeziumCdcHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at.grahsl.kafka.connect.mongodb.cdc.debezium;
+
+import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
+import at.grahsl.kafka.connect.mongodb.cdc.CdcHandler;
+import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class DebeziumCdcHandler extends CdcHandler {
+
+    public static final String OPERATION_TYPE_FIELD_PATH = "op";
+
+    private final Map<OperationType,CdcOperation> operations = new HashMap<>();
+
+    public DebeziumCdcHandler(MongoDbSinkConnectorConfig config) {
+        super(config);
+    }
+
+    protected void registerOperations(Map<OperationType,CdcOperation> operations) {
+        this.operations.putAll(operations);
+    }
+
+    public CdcOperation getCdcOperation(BsonDocument doc) {
+        try {
+            CdcOperation op = operations.get(OperationType.fromText(
+                    doc.get(OPERATION_TYPE_FIELD_PATH).asString().getValue())
+            );
+            if(op == null) {
+                throw new DataException("error: no CDC operation found in mapping for op="
+                        + doc.get(OPERATION_TYPE_FIELD_PATH).asString().getValue());
+            }
+            return op;
+        } catch (IllegalArgumentException exc){
+            throw new DataException("error: parsing CDC operation failed",exc);
+        }
+    }
+
+    public abstract WriteModel<BsonDocument> handle(SinkDocument doc);
+
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mongodb/MongoDbHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mongodb/MongoDbHandler.java
@@ -17,8 +17,8 @@
 package at.grahsl.kafka.connect.mongodb.cdc.debezium.mongodb;
 
 import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
-import at.grahsl.kafka.connect.mongodb.cdc.CdcHandler;
 import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.DebeziumCdcHandler;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
 import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
 import com.mongodb.client.model.WriteModel;
@@ -29,11 +29,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
-public class MongoDbHandler extends CdcHandler {
+public class MongoDbHandler extends DebeziumCdcHandler {
 
     public static final String JSON_ID_FIELD_PATH = "id";
-    public static final String OPERATION_TYPE_FIELD_PATH = "op";
 
     private final Map<OperationType,CdcOperation> operations = new HashMap<>();
     private static Logger logger = LoggerFactory.getLogger(MongoDbHandler.class);
@@ -47,7 +47,7 @@ public class MongoDbHandler extends CdcHandler {
     }
 
     @Override
-    public WriteModel<BsonDocument> handle(SinkDocument doc) {
+    public Optional<WriteModel<BsonDocument>> handle(SinkDocument doc) {
 
         BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
                 () -> new DataException("error: key document must not be missing for CDC mode")
@@ -59,28 +59,13 @@ public class MongoDbHandler extends CdcHandler {
         if(keyDoc.containsKey(JSON_ID_FIELD_PATH)
                 && valueDoc.isEmpty()) {
             logger.debug("skipping debezium tombstone event for kafka topic compaction");
-            return null;
+            return Optional.empty();
         }
 
         logger.debug("key: "+keyDoc.toString());
         logger.debug("value: "+valueDoc.toString());
 
-        return getCdcOperation(valueDoc).perform(doc);
-    }
-
-    private CdcOperation getCdcOperation(BsonDocument doc) {
-        try {
-            CdcOperation op = operations.get(OperationType.fromText(
-                        doc.get(OPERATION_TYPE_FIELD_PATH).asString().getValue())
-            );
-            if(op == null) {
-                throw new DataException("error: no CDC operation found in mapping for "
-                        + doc.get(OPERATION_TYPE_FIELD_PATH).asString().getValue());
-            }
-            return op;
-        } catch (IllegalArgumentException exc){
-            throw new DataException("error: parsing CDC operation failed",exc);
-        }
+        return Optional.of(getCdcOperation(valueDoc).perform(doc));
     }
 
 }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlDelete.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlDelete.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+
+public class MysqlDelete implements CdcOperation {
+
+    @Override
+    public WriteModel<BsonDocument> perform(SinkDocument doc) {
+
+        BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
+                () -> new DataException("error: key doc must not be missing for insert operation")
+        );
+
+        BsonDocument valueDoc = doc.getValueDoc().orElseThrow(
+                () -> new DataException("error: value doc must not be missing for insert operation")
+        );
+
+        try {
+            BsonDocument filterDoc = MysqlHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.DELETE);
+            return new DeleteOneModel<>(filterDoc);
+        } catch(Exception exc) {
+            throw new DataException(exc);
+        }
+
+    }
+
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlDelete.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlDelete.java
@@ -30,11 +30,11 @@ public class MysqlDelete implements CdcOperation {
     public WriteModel<BsonDocument> perform(SinkDocument doc) {
 
         BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
-                () -> new DataException("error: key doc must not be missing for insert operation")
+                () -> new DataException("error: key doc must not be missing for delete operation")
         );
 
         BsonDocument valueDoc = doc.getValueDoc().orElseThrow(
-                () -> new DataException("error: value doc must not be missing for insert operation")
+                () -> new DataException("error: value doc must not be missing for delete operation")
         );
 
         try {

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandler.java
@@ -67,7 +67,7 @@ public class MysqlHandler extends DebeziumCdcHandler {
                             .perform(new SinkDocument(keyDoc,valueDoc)));
     }
 
-    static BsonDocument generateFilterDoc(BsonDocument keyDoc, BsonDocument valueDoc, OperationType opType) {
+    protected static BsonDocument generateFilterDoc(BsonDocument keyDoc, BsonDocument valueDoc, OperationType opType) {
         if (keyDoc.keySet().isEmpty()) {
             if (opType.equals(OperationType.CREATE) || opType.equals(OperationType.READ)) {
                 //create: no PK info in keyDoc -> generate ObjectId
@@ -92,7 +92,7 @@ public class MysqlHandler extends DebeziumCdcHandler {
         return new BsonDocument(DBCollection.ID_FIELD_NAME,pk);
     }
 
-    static BsonDocument generateUpsertOrReplaceDoc(BsonDocument keyDoc, BsonDocument valueDoc, BsonDocument filterDoc) {
+    protected static BsonDocument generateUpsertOrReplaceDoc(BsonDocument keyDoc, BsonDocument valueDoc, BsonDocument filterDoc) {
 
         if (!valueDoc.containsKey(JSON_DOC_AFTER_FIELD)
                 || valueDoc.get(JSON_DOC_AFTER_FIELD).isNull()

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandler.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
+import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.DebeziumCdcHandler;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+import org.bson.BsonObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MysqlHandler extends DebeziumCdcHandler {
+
+    public static final String JSON_DOC_BEFORE_FIELD = "before";
+    public static final String JSON_DOC_AFTER_FIELD = "after";
+
+    private static Logger logger = LoggerFactory.getLogger(MysqlHandler.class);
+
+    public MysqlHandler(MongoDbSinkConnectorConfig config) {
+        super(config);
+        final Map<OperationType,CdcOperation> operations = new HashMap<>();
+        operations.put(OperationType.CREATE,new MysqlInsert());
+        operations.put(OperationType.READ,new MysqlInsert());
+        operations.put(OperationType.UPDATE,new MysqlUpdate());
+        operations.put(OperationType.DELETE,new MysqlDelete());
+        registerOperations(operations);
+    }
+
+    @Override
+    public WriteModel<BsonDocument> handle(SinkDocument doc) {
+        BsonDocument keyDoc = doc.getKeyDoc().orElseGet(() -> new BsonDocument());
+        logger.debug("key: "+keyDoc.toJson());
+        BsonDocument valueDoc = doc.getValueDoc().orElseGet(() -> new BsonDocument());
+        logger.debug("value: "+valueDoc.toJson());
+        if ( (keyDoc.size() >= 0 && valueDoc.isEmpty()) ) {
+            logger.debug("skipping debezium tombstone event for kafka topic compaction");
+            return null;
+        }
+        return getCdcOperation(valueDoc).perform(new SinkDocument(keyDoc,valueDoc));
+    }
+
+    public static BsonDocument generateFilterDoc(BsonDocument keyDoc, BsonDocument valueDoc,OperationType opType) {
+        BsonDocument filterDoc = new BsonDocument();
+        String[] fields = keyDoc.keySet().toArray(new String[0]);
+        if (fields.length == 0) {
+            if(opType.equals(OperationType.CREATE) || opType.equals(OperationType.READ)) {
+                //no PK info in keyDoc -> generate ObjectId
+                filterDoc.put(DBCollection.ID_FIELD_NAME,new BsonObjectId());
+            } else {
+                //no PK info in keyDoc -> take everything in 'before' field
+                filterDoc = valueDoc.getDocument(JSON_DOC_BEFORE_FIELD);
+            }
+        } else {
+            //build filter document composed of all PK columns
+            BsonDocument pk = new BsonDocument();
+            for (String f : fields) {
+                pk.put(f,keyDoc.get(f));
+            }
+            filterDoc.put(DBCollection.ID_FIELD_NAME,pk);
+        }
+        return filterDoc;
+    }
+
+    public static BsonDocument generateUpsertOrReplaceDoc(BsonDocument keyDoc, BsonDocument valueDoc, BsonDocument filterDoc) {
+        BsonDocument upsertDoc = new BsonDocument(
+                DBCollection.ID_FIELD_NAME,filterDoc.get(DBCollection.ID_FIELD_NAME)
+        );
+        if (!valueDoc.containsKey(JSON_DOC_AFTER_FIELD)
+                || valueDoc.get(JSON_DOC_AFTER_FIELD).isNull()
+                || !valueDoc.get(JSON_DOC_AFTER_FIELD).isDocument()) {
+            throw new DataException("error: valueDoc must contain 'after' field" +
+                    " of type document for insert/update operation");
+        }
+        BsonDocument afterDoc = valueDoc.getDocument(JSON_DOC_AFTER_FIELD);
+        for(String f : afterDoc.keySet()) {
+            if(!keyDoc.containsKey(f)) {
+                upsertDoc.put(f,afterDoc.get(f));
+            }
+        }
+        return upsertDoc;
+    }
+
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlInsert.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlInsert.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+
+public class MysqlInsert implements CdcOperation {
+
+    private static final UpdateOptions UPDATE_OPTIONS =
+            new UpdateOptions().upsert(true);
+
+    @Override
+    public WriteModel<BsonDocument> perform(SinkDocument doc) {
+
+        BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
+                () -> new DataException("error: key doc must not be missing for insert operation")
+        );
+
+        BsonDocument valueDoc = doc.getValueDoc().orElseThrow(
+                () -> new DataException("error: value doc must not be missing for insert operation")
+        );
+
+        try {
+            BsonDocument filterDoc = MysqlHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.CREATE);
+            BsonDocument upsertDoc = MysqlHandler.generateUpsertOrReplaceDoc(keyDoc, valueDoc, filterDoc);
+            return new ReplaceOneModel<>(filterDoc, upsertDoc, UPDATE_OPTIONS);
+        } catch (Exception exc) {
+            throw new DataException(exc);
+        }
+
+    }
+
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlUpdate.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlUpdate.java
@@ -34,11 +34,11 @@ public class MysqlUpdate implements CdcOperation {
     public WriteModel<BsonDocument> perform(SinkDocument doc) {
 
         BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
-                () -> new DataException("error: key doc must not be missing for insert operation")
+                () -> new DataException("error: key doc must not be missing for update operation")
         );
 
         BsonDocument valueDoc = doc.getValueDoc().orElseThrow(
-                () -> new DataException("error: value doc must not be missing for insert operation")
+                () -> new DataException("error: value doc must not be missing for update operation")
         );
 
         try {

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlUpdate.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlUpdate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+
+public class MysqlUpdate implements CdcOperation {
+
+    private static final UpdateOptions UPDATE_OPTIONS =
+            new UpdateOptions().upsert(true);
+
+    @Override
+    public WriteModel<BsonDocument> perform(SinkDocument doc) {
+
+        BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
+                () -> new DataException("error: key doc must not be missing for insert operation")
+        );
+
+        BsonDocument valueDoc = doc.getValueDoc().orElseThrow(
+                () -> new DataException("error: value doc must not be missing for insert operation")
+        );
+
+        try {
+            BsonDocument filterDoc = MysqlHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.UPDATE);
+            BsonDocument replaceDoc = MysqlHandler.generateUpsertOrReplaceDoc(keyDoc, valueDoc, filterDoc);
+            return new ReplaceOneModel<>(filterDoc, replaceDoc, UPDATE_OPTIONS);
+        } catch (Exception exc) {
+            throw new DataException(exc);
+        }
+
+    }
+
+
+
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/converter/SinkFieldConverter.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/converter/SinkFieldConverter.java
@@ -20,6 +20,8 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonNull;
 import org.bson.BsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class SinkFieldConverter extends FieldConverter {
 
@@ -29,24 +31,30 @@ public abstract class SinkFieldConverter extends FieldConverter {
 
     public abstract BsonValue toBson(Object data);
 
+    private static Logger logger = LoggerFactory.getLogger(SinkFieldConverter.class);
+
     public BsonValue toBson(Object data, Schema fieldSchema) {
         if(!fieldSchema.isOptional()) {
 
             if(data == null)
                 throw new DataException("error: schema not optional but data was null");
 
+            logger.trace("field not optional and data is '{}'",data.toString());
             return toBson(data);
         }
 
         if(data != null) {
+            logger.trace("field optional and data is '{}'",data.toString());
             return toBson(data);
         }
 
         if(fieldSchema.defaultValue() != null) {
+            logger.trace("field optional and no data but default value is '{}'",fieldSchema.defaultValue().toString());
             return toBson(fieldSchema.defaultValue());
         }
 
-        return new BsonNull();
+        logger.trace("field optional, no data and no default value thus '{}'", BsonNull.VALUE);
+        return BsonNull.VALUE;
     }
 
 }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/converter/SinkFieldConverter.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/converter/SinkFieldConverter.java
@@ -25,13 +25,13 @@ import org.slf4j.LoggerFactory;
 
 public abstract class SinkFieldConverter extends FieldConverter {
 
+    private static Logger logger = LoggerFactory.getLogger(SinkFieldConverter.class);
+
     public SinkFieldConverter(Schema schema) {
         super(schema);
     }
 
     public abstract BsonValue toBson(Object data);
-
-    private static Logger logger = LoggerFactory.getLogger(SinkFieldConverter.class);
 
     public BsonValue toBson(Object data, Schema fieldSchema) {
         if(!fieldSchema.isOptional()) {

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mongodb/MongoDbHandlerTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mongodb/MongoDbHandlerTest.java
@@ -5,6 +5,7 @@ import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
+import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,8 +13,9 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import java.util.HashMap;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @RunWith(JUnitPlatform.class)
@@ -33,20 +35,45 @@ public class MongoDbHandlerTest {
     @Test
     @DisplayName("when key doc contains 'id' field but value is empty then null due to tombstone")
     public void testTombstoneEvent() {
-        assertNull(
+        assertEquals(Optional.empty(),
                 MONGODB_HANDLER.handle(new SinkDocument(
                         new BsonDocument("id",new BsonInt32(1234)),
                             new BsonDocument())
-                )
+                ),
+                "tombstone event must result in Optional.empty()"
         );
     }
 
     @Test
-    @DisplayName("when value doc contains invalid operation type then DataException")
+    @DisplayName("when value doc contains unknown operation type then DataException")
+    public void testUnkownCdcOperationType() {
+        SinkDocument cdcEvent = new SinkDocument(
+                new BsonDocument("id",new BsonInt32(1234)),
+                new BsonDocument("op",new BsonString("x"))
+        );
+        assertThrows(DataException.class, () ->
+                MONGODB_HANDLER.handle(cdcEvent)
+        );
+    }
+
+    @Test
+    @DisplayName("when value doc contains operation type other than string then DataException")
     public void testInvalidCdcOperationType() {
         SinkDocument cdcEvent = new SinkDocument(
                 new BsonDocument("id",new BsonInt32(1234)),
-                        new BsonDocument("op",new BsonString("x"))
+                new BsonDocument("op",new BsonInt32('c'))
+        );
+        assertThrows(DataException.class, () ->
+                MONGODB_HANDLER.handle(cdcEvent)
+        );
+    }
+
+    @Test
+    @DisplayName("when value doc is missing operation type then DataException")
+    public void testMissingCdcOperationType() {
+        SinkDocument cdcEvent = new SinkDocument(
+                new BsonDocument("id",new BsonInt32(1234)),
+                new BsonDocument("po", BsonNull.VALUE)
         );
         assertThrows(DataException.class, () ->
                 MONGODB_HANDLER.handle(cdcEvent)

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlDeleteTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlDeleteTest.java
@@ -1,0 +1,103 @@
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(JUnitPlatform.class)
+public class MysqlDeleteTest {
+
+    public static final MysqlDelete MYSQL_DELETE = new MysqlDelete();
+
+    public static final BsonDocument FILTER_DOC_1 =
+            new BsonDocument(DBCollection.ID_FIELD_NAME,
+                    new BsonDocument("id",new BsonInt32(1004)));
+
+    public static final BsonDocument FILTER_DOC_2 =
+                    new BsonDocument("id",new BsonInt32(1004));
+
+
+    @Test
+    @DisplayName("when valid cdc event with key doc fields then correct DeleteOneModel")
+    public void testValidSinkDocumentBasedOnKey() {
+
+        BsonDocument keyDoc = new BsonDocument("id",new BsonInt32(1004));
+        BsonDocument valueDoc = new BsonDocument("op",new BsonString("d"));
+
+        WriteModel<BsonDocument> result =
+                MYSQL_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
+
+        assertTrue(result instanceof DeleteOneModel,
+                () -> "result expected to be of type DeleteOneModel");
+
+        DeleteOneModel<BsonDocument> writeModel =
+                (DeleteOneModel<BsonDocument>) result;
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(FILTER_DOC_1,writeModel.getFilter());
+
+    }
+
+    @Test
+    @DisplayName("when valid cdc event without key doc fields but 'before' value doc then correct DeleteOneModel")
+    public void testValidSinkDocumentBasedOnBeforeValueField() {
+
+        BsonDocument keyDoc = new BsonDocument();
+        BsonDocument valueDoc = new BsonDocument("op",new BsonString("d"))
+                                        .append("before",new BsonDocument("id",new BsonInt32(1004)));
+
+        WriteModel<BsonDocument> result =
+                MYSQL_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
+
+        assertTrue(result instanceof DeleteOneModel,
+                () -> "result expected to be of type DeleteOneModel");
+
+        DeleteOneModel<BsonDocument> writeModel =
+                (DeleteOneModel<BsonDocument>) result;
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(FILTER_DOC_2,writeModel.getFilter());
+
+    }
+
+    @Test
+    @DisplayName("when missing key doc then DataException")
+    public void testMissingKeyDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_DELETE.perform(new SinkDocument(null,new BsonDocument()))
+        );
+    }
+
+    @Test
+    @DisplayName("when missing value doc then DataException")
+    public void testMissingValueDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_DELETE.perform(new SinkDocument(new BsonDocument(),null))
+        );
+    }
+
+    @Test
+    @DisplayName("when key doc and value 'before' field empty then DataException")
+    public void testEmptyKeyDocAndEmptyValueBeforeField() {
+        assertThrows(DataException.class,() ->
+                MYSQL_DELETE.perform(new SinkDocument(new BsonDocument(),
+                        new BsonDocument("op",new BsonString("d")).append("before",new BsonDocument())))
+        );
+    }
+
+}

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandlerTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandlerTest.java
@@ -1,0 +1,56 @@
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@RunWith(JUnitPlatform.class)
+public class MysqlHandlerTest {
+
+    public static final MysqlHandler MYSQL_HANDLER =
+            new MysqlHandler(new MongoDbSinkConnectorConfig(new HashMap<>()));
+
+    @Test
+    @DisplayName("when key document missing then DataException")
+    public void testMissingKeyDocument() {
+        assertThrows(DataException.class, () ->
+            MYSQL_HANDLER.handle(new SinkDocument(null,null))
+        );
+    }
+
+    @Test
+    @DisplayName("when key doc contains 'id' field but value is empty then null due to tombstone")
+    public void testTombstoneEvent() {
+        assertNull(
+                MYSQL_HANDLER.handle(new SinkDocument(
+                        new BsonDocument("id",new BsonInt32(1234)),
+                            new BsonDocument())
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("when value doc contains invalid operation type then DataException")
+    public void testInvalidCdcOperationType() {
+        SinkDocument cdcEvent = new SinkDocument(
+                new BsonDocument("id",new BsonInt32(1234)),
+                        new BsonDocument("op",new BsonString("x"))
+        );
+        assertThrows(DataException.class, () ->
+                MYSQL_HANDLER.handle(cdcEvent)
+        );
+    }
+
+}

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandlerTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlHandlerTest.java
@@ -5,6 +5,7 @@ import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
+import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,8 +13,9 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import java.util.HashMap;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @RunWith(JUnitPlatform.class)
@@ -23,30 +25,54 @@ public class MysqlHandlerTest {
             new MysqlHandler(new MongoDbSinkConnectorConfig(new HashMap<>()));
 
     @Test
-    @DisplayName("when key document missing then DataException")
-    public void testMissingKeyDocument() {
-        assertThrows(DataException.class, () ->
-            MYSQL_HANDLER.handle(new SinkDocument(null,null))
-        );
-    }
-
-    @Test
-    @DisplayName("when key doc contains 'id' field but value is empty then null due to tombstone")
-    public void testTombstoneEvent() {
-        assertNull(
+    @DisplayName("when key doc contains fields but value is empty then null due to tombstone")
+    public void testTombstoneEvent1() {
+        assertEquals(Optional.empty(),
                 MYSQL_HANDLER.handle(new SinkDocument(
-                        new BsonDocument("id",new BsonInt32(1234)),
-                            new BsonDocument())
-                )
+                        new BsonDocument("id",new BsonInt32(1234)), new BsonDocument())),
+                "tombstone event must result in Optional.empty()"
         );
     }
 
     @Test
-    @DisplayName("when value doc contains invalid operation type then DataException")
-    public void testInvalidCdcOperationType() {
+    @DisplayName("when both key doc and value value doc are empty then null due to tombstone")
+    public void testTombstoneEvent2() {
+        assertEquals(Optional.empty(),
+                MYSQL_HANDLER.handle(new SinkDocument(new BsonDocument(), new BsonDocument())),
+                "tombstone event must result in Optional.empty()"
+        );
+    }
+
+    @Test
+    @DisplayName("when value doc contains unknown operation type then DataException")
+    public void testUnkownCdcOperationType() {
         SinkDocument cdcEvent = new SinkDocument(
                 new BsonDocument("id",new BsonInt32(1234)),
                         new BsonDocument("op",new BsonString("x"))
+        );
+        assertThrows(DataException.class, () ->
+                MYSQL_HANDLER.handle(cdcEvent)
+        );
+    }
+
+    @Test
+    @DisplayName("when value doc contains operation type other than string then DataException")
+    public void testInvalidCdcOperationType() {
+        SinkDocument cdcEvent = new SinkDocument(
+                new BsonDocument("id",new BsonInt32(1234)),
+                new BsonDocument("op",new BsonInt32('c'))
+        );
+        assertThrows(DataException.class, () ->
+                MYSQL_HANDLER.handle(cdcEvent)
+        );
+    }
+
+    @Test
+    @DisplayName("when value doc is missing operation type then DataException")
+    public void testMissingCdcOperationType() {
+        SinkDocument cdcEvent = new SinkDocument(
+                new BsonDocument("id",new BsonInt32(1234)),
+                new BsonDocument("po",BsonNull.VALUE)
         );
         assertThrows(DataException.class, () ->
                 MYSQL_HANDLER.handle(cdcEvent)

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlInsertTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlInsertTest.java
@@ -1,0 +1,96 @@
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(JUnitPlatform.class)
+public class MysqlInsertTest {
+
+    public static final MysqlInsert MYSQL_INSERT = new MysqlInsert();
+
+    public static final BsonDocument FILTER_DOC =
+            new BsonDocument(DBCollection.ID_FIELD_NAME,
+                    new BsonDocument("id",new BsonInt32(1004)));
+
+    public static final BsonDocument REPLACEMENT_DOC =
+            new BsonDocument(DBCollection.ID_FIELD_NAME,
+                    new BsonDocument("id",new BsonInt32(1004)))
+                    .append("first_name",new BsonString("Anne"))
+                    .append("last_name",new BsonString("Kretchmar"))
+                    .append("email",new BsonString("annek@noanswer.org"));
+
+    @Test
+    @DisplayName("when valid cdc event then correct ReplaceOneModel")
+    public void testValidSinkDocument() {
+
+        BsonDocument keyDoc = new BsonDocument("id",new BsonInt32(1004));
+
+        BsonDocument valueDoc = new BsonDocument("op",new BsonString("c"))
+                .append("after",new BsonDocument("id",new BsonInt32(1004))
+                        .append("first_name",new BsonString("Anne"))
+                        .append("last_name",new BsonString("Kretchmar"))
+                        .append("email",new BsonString("annek@noanswer.org")));
+
+        WriteModel<BsonDocument> result =
+                MYSQL_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
+
+        assertTrue(result instanceof ReplaceOneModel,
+                () -> "result expected to be of type ReplaceOneModel");
+
+        ReplaceOneModel<BsonDocument> writeModel =
+                (ReplaceOneModel<BsonDocument>) result;
+
+        assertEquals(REPLACEMENT_DOC,writeModel.getReplacement(),
+                ()-> "replacement doc not matching what is expected");
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(FILTER_DOC,writeModel.getFilter());
+
+        assertTrue(writeModel.getOptions().isUpsert(),
+                () -> "replacement expected to be done in upsert mode");
+
+    }
+
+    @Test
+    @DisplayName("when missing key doc then DataException")
+    public void testMissingKeyDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_INSERT.perform(new SinkDocument(null, new BsonDocument()))
+        );
+    }
+
+    @Test
+    @DisplayName("when missing value doc then DataException")
+    public void testMissingValueDocument() {
+        assertThrows(DataException.class,() ->
+            MYSQL_INSERT.perform(new SinkDocument(new BsonDocument(),null))
+        );
+    }
+
+    @Test
+    @DisplayName("when invalid json in value doc 'after' field then DataException")
+    public void testInvalidAfterField() {
+        assertThrows(DataException.class,() ->
+                MYSQL_INSERT.perform(
+                        new SinkDocument(new BsonDocument(),
+                            new BsonDocument("op",new BsonString("c"))
+                                .append("after",new BsonString("{NO : JSON [HERE] GO : AWAY}")))
+                )
+        );
+    }
+
+}

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlInsertTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlInsertTest.java
@@ -5,9 +5,7 @@ import com.mongodb.DBCollection;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.WriteModel;
 import org.apache.kafka.connect.errors.DataException;
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonString;
+import org.bson.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -20,20 +18,20 @@ public class MysqlInsertTest {
 
     public static final MysqlInsert MYSQL_INSERT = new MysqlInsert();
 
-    public static final BsonDocument FILTER_DOC =
-            new BsonDocument(DBCollection.ID_FIELD_NAME,
-                    new BsonDocument("id",new BsonInt32(1004)));
-
-    public static final BsonDocument REPLACEMENT_DOC =
-            new BsonDocument(DBCollection.ID_FIELD_NAME,
-                    new BsonDocument("id",new BsonInt32(1004)))
-                    .append("first_name",new BsonString("Anne"))
-                    .append("last_name",new BsonString("Kretchmar"))
-                    .append("email",new BsonString("annek@noanswer.org"));
-
     @Test
-    @DisplayName("when valid cdc event then correct ReplaceOneModel")
-    public void testValidSinkDocument() {
+    @DisplayName("when valid cdc event with single field PK then correct ReplaceOneModel")
+    public void testValidSinkDocumentSingleFieldPK() {
+
+        BsonDocument filterDoc =
+                new BsonDocument(DBCollection.ID_FIELD_NAME,
+                        new BsonDocument("id",new BsonInt32(1004)));
+
+        BsonDocument replacementDoc =
+                new BsonDocument(DBCollection.ID_FIELD_NAME,
+                        new BsonDocument("id",new BsonInt32(1004)))
+                        .append("first_name",new BsonString("Anne"))
+                        .append("last_name",new BsonString("Kretchmar"))
+                        .append("email",new BsonString("annek@noanswer.org"));
 
         BsonDocument keyDoc = new BsonDocument("id",new BsonInt32(1004));
 
@@ -52,13 +50,117 @@ public class MysqlInsertTest {
         ReplaceOneModel<BsonDocument> writeModel =
                 (ReplaceOneModel<BsonDocument>) result;
 
-        assertEquals(REPLACEMENT_DOC,writeModel.getReplacement(),
+        assertEquals(replacementDoc,writeModel.getReplacement(),
                 ()-> "replacement doc not matching what is expected");
 
         assertTrue(writeModel.getFilter() instanceof BsonDocument,
                 () -> "filter expected to be of type BsonDocument");
 
-        assertEquals(FILTER_DOC,writeModel.getFilter());
+        assertEquals(filterDoc,writeModel.getFilter());
+
+        assertTrue(writeModel.getOptions().isUpsert(),
+                () -> "replacement expected to be done in upsert mode");
+
+    }
+
+    @Test
+    @DisplayName("when valid cdc event with compound PK then correct ReplaceOneModel")
+    public void testValidSinkDocumentCompoundPK() {
+
+        BsonDocument filterDoc =
+                new BsonDocument(DBCollection.ID_FIELD_NAME,
+                        new BsonDocument("idA",new BsonInt32(123))
+                                .append("idB",new BsonString("ABC")));
+
+        BsonDocument replacementDoc =
+                new BsonDocument(DBCollection.ID_FIELD_NAME,
+                        new BsonDocument("idA",new BsonInt32(123))
+                                .append("idB",new BsonString("ABC")))
+                        .append("number", new BsonDouble(567.89))
+                        .append("active", new BsonBoolean(true));
+
+        BsonDocument keyDoc = new BsonDocument("idA",new BsonInt32(123))
+                                    .append("idB",new BsonString("ABC"));
+
+        BsonDocument valueDoc = new BsonDocument("op",new BsonString("c"))
+                .append("after",new BsonDocument("idA",new BsonInt32(123))
+                                        .append("idB",new BsonString("ABC"))
+                                    .append("number", new BsonDouble(567.89))
+                                    .append("active", new BsonBoolean(true)));
+
+        WriteModel<BsonDocument> result =
+                MYSQL_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
+
+        assertTrue(result instanceof ReplaceOneModel,
+                () -> "result expected to be of type ReplaceOneModel");
+
+        ReplaceOneModel<BsonDocument> writeModel =
+                (ReplaceOneModel<BsonDocument>) result;
+
+        assertEquals(replacementDoc,writeModel.getReplacement(),
+                ()-> "replacement doc not matching what is expected");
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(filterDoc,writeModel.getFilter());
+
+        assertTrue(writeModel.getOptions().isUpsert(),
+                () -> "replacement expected to be done in upsert mode");
+
+    }
+
+    @Test
+    @DisplayName("when valid cdc event without PK then correct ReplaceOneModel")
+    public void testValidSinkDocumentNoPK() {
+
+        //NOTE: for both filterDoc and replacementDoc _id is a generated ObjectId
+        //which cannot be set from outside for testing thus it is set
+        //by taking it from the resulting writeModel in order to do an equals comparison
+        //for all contained fields
+
+        BsonDocument filterDoc = new BsonDocument();
+
+        BsonDocument replacementDoc =
+                        new BsonDocument("text", new BsonString("lalala"))
+                        .append("number", new BsonInt32(1234))
+                        .append("active", new BsonBoolean(false));
+
+        BsonDocument keyDoc = new BsonDocument();
+
+        BsonDocument valueDoc = new BsonDocument("op",new BsonString("c"))
+                .append("after",new BsonDocument("text", new BsonString("lalala"))
+                        .append("number", new BsonInt32(1234))
+                        .append("active", new BsonBoolean(false)));
+
+        WriteModel<BsonDocument> result =
+                MYSQL_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
+
+        assertTrue(result instanceof ReplaceOneModel,
+                () -> "result expected to be of type ReplaceOneModel");
+
+        ReplaceOneModel<BsonDocument> writeModel =
+                (ReplaceOneModel<BsonDocument>) result;
+
+        assertTrue(writeModel.getReplacement().isObjectId(DBCollection.ID_FIELD_NAME),
+                () -> "replacement doc must contain _id field of type ObjectID");
+
+        replacementDoc.put(DBCollection.ID_FIELD_NAME,
+                writeModel.getReplacement().get(DBCollection.ID_FIELD_NAME,new BsonObjectId()));
+
+        assertEquals(replacementDoc,writeModel.getReplacement(),
+                ()-> "replacement doc not matching what is expected");
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertTrue(((BsonDocument)writeModel.getFilter()).isObjectId(DBCollection.ID_FIELD_NAME),
+                () -> "filter doc must contain _id field of type ObjectID");
+
+        filterDoc.put(DBCollection.ID_FIELD_NAME,
+                ((BsonDocument)writeModel.getFilter()).get(DBCollection.ID_FIELD_NAME,new BsonObjectId()));
+
+        assertEquals(filterDoc,writeModel.getFilter());
 
         assertTrue(writeModel.getOptions().isUpsert(),
                 () -> "replacement expected to be done in upsert mode");

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlUpdateTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/mysql/MysqlUpdateTest.java
@@ -1,0 +1,134 @@
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(JUnitPlatform.class)
+public class MysqlUpdateTest {
+
+    public static final MysqlUpdate MYSQL_UPDATE = new MysqlUpdate();
+
+    public static final BsonDocument FILTER_DOC =
+            new BsonDocument(DBCollection.ID_FIELD_NAME,
+                    new BsonDocument("id",new BsonInt32(1004)));
+
+    public static final BsonDocument REPLACEMENT_DOC =
+            new BsonDocument(DBCollection.ID_FIELD_NAME,
+                    new BsonDocument("id",new BsonInt32(1004)))
+                    .append("first_name",new BsonString("Anne"))
+                    .append("last_name",new BsonString("Kretchmar"))
+                    .append("email",new BsonString("annek@noanswer.org"));
+
+    @Test
+    @DisplayName("when valid cdc event then correct ReplaceOneModel")
+    public void testValidSinkDocumentForReplacement() {
+
+        BsonDocument keyDoc = new BsonDocument("id",new BsonInt32(1004));
+
+        BsonDocument valueDoc = new BsonDocument("op",new BsonString("u"))
+                .append("after",new BsonDocument("id",new BsonInt32(1004))
+                        .append("first_name",new BsonString("Anne"))
+                        .append("last_name",new BsonString("Kretchmar"))
+                        .append("email",new BsonString("annek@noanswer.org")));
+
+        WriteModel<BsonDocument> result =
+                MYSQL_UPDATE.perform(new SinkDocument(keyDoc,valueDoc));
+
+        assertTrue(result instanceof ReplaceOneModel,
+                () -> "result expected to be of type ReplaceOneModel");
+
+        ReplaceOneModel<BsonDocument> writeModel =
+                (ReplaceOneModel<BsonDocument>) result;
+
+        assertEquals(REPLACEMENT_DOC,writeModel.getReplacement(),
+                ()-> "replacement doc not matching what is expected");
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(FILTER_DOC,writeModel.getFilter());
+
+        assertTrue(writeModel.getOptions().isUpsert(),
+                () -> "replacement expected to be done in upsert mode");
+
+    }
+
+    @Test
+    @DisplayName("when missing key doc then DataException")
+    public void testMissingKeyDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_UPDATE.perform(new SinkDocument(null, new BsonDocument()))
+        );
+    }
+
+    @Test
+    @DisplayName("when missing value doc then DataException")
+    public void testMissingValueDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument(),null))
+        );
+    }
+
+
+    @Test
+    @DisplayName("when 'after' field missing in value doc then DataException")
+    public void testMissingAfterFieldInValueDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                        new BsonDocument("op",new BsonString("u"))))
+        );
+    }
+
+    @Test
+    @DisplayName("when 'after' field empty in value doc then DataException")
+    public void testEmptyAfterFieldInValueDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                        new BsonDocument("op",new BsonString("u"))
+                                .append("after",new BsonDocument())))
+        );
+    }
+
+    @Test
+    @DisplayName("when 'after' field null in value doc then DataException")
+    public void testNullAfterFieldInValueDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                        new BsonDocument("op",new BsonString("u"))
+                                .append("after",new BsonNull())))
+        );
+    }
+
+    @Test
+    @DisplayName("when 'after' field no document in value doc then DataException")
+    public void testNoDocumentAfterFieldInValueDocument() {
+        assertThrows(DataException.class,() ->
+                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                        new BsonDocument("op",new BsonString("u"))
+                                .append("after",new BsonString("wrong type"))))
+        );
+    }
+
+    @Test
+    @DisplayName("when key doc and value 'before' field empty then DataException")
+    public void testEmptyKeyDocAndEmptyValueBeforeField() {
+        assertThrows(DataException.class,() ->
+                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument(),
+                        new BsonDocument("before",new BsonDocument())))
+        );
+    }
+
+}


### PR DESCRIPTION
integrate support for processing mysql cdc events from debezium. currently there is no explicit DDL message handling but due to monogdb's flexible schema basic use cases like e.g. adding a new column are working nevertheless.