### PR TITLE
add support for DBZ postgresql CDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,10 +360,10 @@ The sink connector can also be used in a different operation mode in order to ha
 
 * [MongoDB](http://debezium.io/docs/connectors/mongodb/) 
 * [MySQL](http://debezium.io/docs/connectors/mysql/)
-* PostgreSQL (coming later)
+* [PostgreSQL](http://debezium.io/docs/connectors/postgresql/)
 * Oracle (not yet finished at Debezium Project)
 
-This effectively allows to replicate all state changes within the source databases into MongoDB collections. Further Debezium formats - namely PostgreSQL and Oracle - will probably get integrated in future releases.
+This effectively allows to replicate all state changes within the source databases into MongoDB collections. Debezium produces very similar CDC events for MySQL and PostgreSQL. The so far addressed use cases worked fine based on the same code which is why there is only one _RdbmsHandler_ implementation to support them both at the moment. Debezium Oracle CDC format will be integrated in a future release.
  
 Also note that **both serialization formats (JSON+Schema & AVRO) can be used** depending on which configuration is a better fit for your use case.
 

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
@@ -18,7 +18,8 @@ package at.grahsl.kafka.connect.mongodb;
 
 import at.grahsl.kafka.connect.mongodb.cdc.CdcHandler;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.mongodb.MongoDbHandler;
-import at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql.MysqlHandler;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms.mysql.MysqlHandler;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms.postgres.PostgresHandler;
 import at.grahsl.kafka.connect.mongodb.processor.*;
 import at.grahsl.kafka.connect.mongodb.processor.field.projection.FieldProjector;
 import at.grahsl.kafka.connect.mongodb.processor.field.renaming.FieldnameMapping;
@@ -313,6 +314,7 @@ public class MongoDbSinkConnectorConfig extends AbstractConfig {
         Set<String> cdcHandlers = new HashSet<String>();
         cdcHandlers.add(MongoDbHandler.class.getName());
         cdcHandlers.add(MysqlHandler.class.getName());
+        cdcHandlers.add(PostgresHandler.class.getName());
         return cdcHandlers;
     }
 

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsDelete.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsDelete.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
@@ -24,7 +24,7 @@ import com.mongodb.client.model.WriteModel;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonDocument;
 
-public class MysqlDelete implements CdcOperation {
+public class RdbmsDelete implements CdcOperation {
 
     @Override
     public WriteModel<BsonDocument> perform(SinkDocument doc) {
@@ -38,7 +38,7 @@ public class MysqlDelete implements CdcOperation {
         );
 
         try {
-            BsonDocument filterDoc = MysqlHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.DELETE);
+            BsonDocument filterDoc = RdbmsHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.DELETE);
             return new DeleteOneModel<>(filterDoc);
         } catch(Exception exc) {
             throw new DataException(exc);

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsHandler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
 import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
@@ -34,25 +34,25 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public class MysqlHandler extends DebeziumCdcHandler {
+public class RdbmsHandler extends DebeziumCdcHandler {
 
     public static final String JSON_DOC_BEFORE_FIELD = "before";
     public static final String JSON_DOC_AFTER_FIELD = "after";
 
-    private static Logger logger = LoggerFactory.getLogger(MysqlHandler.class);
+    private static Logger logger = LoggerFactory.getLogger(RdbmsHandler.class);
 
-    public MysqlHandler(MongoDbSinkConnectorConfig config) {
+    public RdbmsHandler(MongoDbSinkConnectorConfig config) {
         super(config);
         final Map<OperationType,CdcOperation> operations = new HashMap<>();
-        operations.put(OperationType.CREATE,new MysqlInsert());
-        operations.put(OperationType.READ,new MysqlInsert());
-        operations.put(OperationType.UPDATE,new MysqlUpdate());
-        operations.put(OperationType.DELETE,new MysqlDelete());
+        operations.put(OperationType.CREATE,new RdbmsInsert());
+        operations.put(OperationType.READ,new RdbmsInsert());
+        operations.put(OperationType.UPDATE,new RdbmsUpdate());
+        operations.put(OperationType.DELETE,new RdbmsDelete());
         registerOperations(operations);
     }
 
-    public MysqlHandler(MongoDbSinkConnectorConfig config,
-                          Map<OperationType,CdcOperation> operations) {
+    public RdbmsHandler(MongoDbSinkConnectorConfig config,
+                        Map<OperationType,CdcOperation> operations) {
         super(config);
         registerOperations(operations);
     }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsInsert.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsInsert.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
@@ -25,7 +25,7 @@ import com.mongodb.client.model.WriteModel;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonDocument;
 
-public class MysqlUpdate implements CdcOperation {
+public class RdbmsInsert implements CdcOperation {
 
     private static final UpdateOptions UPDATE_OPTIONS =
             new UpdateOptions().upsert(true);
@@ -34,23 +34,21 @@ public class MysqlUpdate implements CdcOperation {
     public WriteModel<BsonDocument> perform(SinkDocument doc) {
 
         BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
-                () -> new DataException("error: key doc must not be missing for update operation")
+                () -> new DataException("error: key doc must not be missing for insert operation")
         );
 
         BsonDocument valueDoc = doc.getValueDoc().orElseThrow(
-                () -> new DataException("error: value doc must not be missing for update operation")
+                () -> new DataException("error: value doc must not be missing for insert operation")
         );
 
         try {
-            BsonDocument filterDoc = MysqlHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.UPDATE);
-            BsonDocument replaceDoc = MysqlHandler.generateUpsertOrReplaceDoc(keyDoc, valueDoc, filterDoc);
-            return new ReplaceOneModel<>(filterDoc, replaceDoc, UPDATE_OPTIONS);
+            BsonDocument filterDoc = RdbmsHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.CREATE);
+            BsonDocument upsertDoc = RdbmsHandler.generateUpsertOrReplaceDoc(keyDoc, valueDoc, filterDoc);
+            return new ReplaceOneModel<>(filterDoc, upsertDoc, UPDATE_OPTIONS);
         } catch (Exception exc) {
             throw new DataException(exc);
         }
 
     }
-
-
 
 }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsUpdate.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsUpdate.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
@@ -25,7 +25,7 @@ import com.mongodb.client.model.WriteModel;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonDocument;
 
-public class MysqlInsert implements CdcOperation {
+public class RdbmsUpdate implements CdcOperation {
 
     private static final UpdateOptions UPDATE_OPTIONS =
             new UpdateOptions().upsert(true);
@@ -34,21 +34,23 @@ public class MysqlInsert implements CdcOperation {
     public WriteModel<BsonDocument> perform(SinkDocument doc) {
 
         BsonDocument keyDoc = doc.getKeyDoc().orElseThrow(
-                () -> new DataException("error: key doc must not be missing for insert operation")
+                () -> new DataException("error: key doc must not be missing for update operation")
         );
 
         BsonDocument valueDoc = doc.getValueDoc().orElseThrow(
-                () -> new DataException("error: value doc must not be missing for insert operation")
+                () -> new DataException("error: value doc must not be missing for update operation")
         );
 
         try {
-            BsonDocument filterDoc = MysqlHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.CREATE);
-            BsonDocument upsertDoc = MysqlHandler.generateUpsertOrReplaceDoc(keyDoc, valueDoc, filterDoc);
-            return new ReplaceOneModel<>(filterDoc, upsertDoc, UPDATE_OPTIONS);
+            BsonDocument filterDoc = RdbmsHandler.generateFilterDoc(keyDoc, valueDoc, OperationType.UPDATE);
+            BsonDocument replaceDoc = RdbmsHandler.generateUpsertOrReplaceDoc(keyDoc, valueDoc, filterDoc);
+            return new ReplaceOneModel<>(filterDoc, replaceDoc, UPDATE_OPTIONS);
         } catch (Exception exc) {
             throw new DataException(exc);
         }
 
     }
+
+
 
 }

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/mysql/MysqlHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/mysql/MysqlHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms.mysql;
+
+import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
+import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms.RdbmsHandler;
+
+import java.util.Map;
+
+public class MysqlHandler extends RdbmsHandler {
+
+    //NOTE: this class is prepared in case there are
+    //mysql specific differences to be considered
+    //and the CDC handling deviates from the standard
+    //behaviour as implemented in RdbmsHandler.class
+
+    public MysqlHandler(MongoDbSinkConnectorConfig config) {
+        super(config);
+    }
+
+    public MysqlHandler(MongoDbSinkConnectorConfig config, Map<OperationType, CdcOperation> operations) {
+        super(config, operations);
+    }
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/postgres/PostgresHandler.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/postgres/PostgresHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms.postgres;
+
+import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
+import at.grahsl.kafka.connect.mongodb.cdc.CdcOperation;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
+import at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms.RdbmsHandler;
+
+import java.util.Map;
+
+public class PostgresHandler extends RdbmsHandler {
+
+    //NOTE: this class is prepared in case there are
+    //postgres specific differences to be considered
+    //and the CDC handling deviates from the standard
+    //behaviour as implemented in RdbmsHandler.class
+
+    public PostgresHandler(MongoDbSinkConnectorConfig config) {
+        super(config);
+    }
+
+    public PostgresHandler(MongoDbSinkConnectorConfig config, Map<OperationType, CdcOperation> operations) {
+        super(config, operations);
+    }
+
+}

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsDeleteTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsDeleteTest.java
@@ -1,4 +1,4 @@
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
 import com.mongodb.DBCollection;
@@ -17,9 +17,9 @@ import org.junit.runner.RunWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(JUnitPlatform.class)
-public class MysqlDeleteTest {
+public class RdbmsDeleteTest {
 
-    public static final MysqlDelete MYSQL_DELETE = new MysqlDelete();
+    public static final RdbmsDelete RDBMS_DELETE = new RdbmsDelete();
 
     @Test
     @DisplayName("when valid cdc event with single field PK then correct DeleteOneModel")
@@ -33,7 +33,7 @@ public class MysqlDeleteTest {
         BsonDocument valueDoc = new BsonDocument("op",new BsonString("d"));
 
         WriteModel<BsonDocument> result =
-                MYSQL_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof DeleteOneModel,
                 () -> "result expected to be of type DeleteOneModel");
@@ -62,7 +62,7 @@ public class MysqlDeleteTest {
         BsonDocument valueDoc = new BsonDocument("op",new BsonString("d"));
 
         WriteModel<BsonDocument> result =
-                MYSQL_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof DeleteOneModel,
                 () -> "result expected to be of type DeleteOneModel");
@@ -93,7 +93,7 @@ public class MysqlDeleteTest {
                         .append("active", new BsonBoolean(true)));
 
         WriteModel<BsonDocument> result =
-                MYSQL_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_DELETE.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof DeleteOneModel,
                 () -> "result expected to be of type DeleteOneModel");
@@ -112,7 +112,7 @@ public class MysqlDeleteTest {
     @DisplayName("when missing key doc then DataException")
     public void testMissingKeyDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_DELETE.perform(new SinkDocument(null,new BsonDocument()))
+                RDBMS_DELETE.perform(new SinkDocument(null,new BsonDocument()))
         );
     }
 
@@ -120,7 +120,7 @@ public class MysqlDeleteTest {
     @DisplayName("when missing value doc then DataException")
     public void testMissingValueDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_DELETE.perform(new SinkDocument(new BsonDocument(),null))
+                RDBMS_DELETE.perform(new SinkDocument(new BsonDocument(),null))
         );
     }
 
@@ -128,7 +128,7 @@ public class MysqlDeleteTest {
     @DisplayName("when key doc and value 'before' field both empty then DataException")
     public void testEmptyKeyDocAndEmptyValueBeforeField() {
         assertThrows(DataException.class,() ->
-                MYSQL_DELETE.perform(new SinkDocument(new BsonDocument(),
+                RDBMS_DELETE.perform(new SinkDocument(new BsonDocument(),
                         new BsonDocument("op",new BsonString("d")).append("before",new BsonDocument())))
         );
     }

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsHandlerTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsHandlerTest.java
@@ -1,4 +1,4 @@
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.MongoDbSinkConnectorConfig;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.OperationType;
@@ -26,22 +26,22 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 @RunWith(JUnitPlatform.class)
-public class MysqlHandlerTest {
+public class RdbmsHandlerTest {
 
-    public static final MysqlHandler MYSQL_HANDLER_DEFAULT_MAPPING =
-            new MysqlHandler(new MongoDbSinkConnectorConfig(new HashMap<>()));
+    public static final RdbmsHandler RDBMS_HANDLER_DEFAULT_MAPPING =
+            new RdbmsHandler(new MongoDbSinkConnectorConfig(new HashMap<>()));
 
-    public static final MysqlHandler MYSQL_HANDLER_EMPTY_MAPPING =
-            new MysqlHandler(new MongoDbSinkConnectorConfig(new HashMap<>()),
+    public static final RdbmsHandler RDBMS_HANDLER_EMPTY_MAPPING =
+            new RdbmsHandler(new MongoDbSinkConnectorConfig(new HashMap<>()),
                     new HashMap<>());
 
     @Test
     @DisplayName("verify existing default config from base class")
     public void testExistingDefaultConfig() {
         assertAll(
-                () -> assertNotNull(MYSQL_HANDLER_DEFAULT_MAPPING.getConfig(),
+                () -> assertNotNull(RDBMS_HANDLER_DEFAULT_MAPPING.getConfig(),
                         () -> "default config for handler must not be null"),
-                () -> assertNotNull(MYSQL_HANDLER_EMPTY_MAPPING.getConfig(),
+                () -> assertNotNull(RDBMS_HANDLER_EMPTY_MAPPING.getConfig(),
                         () -> "default config for handler must not be null")
         );
     }
@@ -50,7 +50,7 @@ public class MysqlHandlerTest {
     @DisplayName("when key doc contains fields but value is empty then null due to tombstone")
     public void testTombstoneEvent1() {
         assertEquals(Optional.empty(),
-                MYSQL_HANDLER_DEFAULT_MAPPING.handle(new SinkDocument(
+                RDBMS_HANDLER_DEFAULT_MAPPING.handle(new SinkDocument(
                         new BsonDocument("id",new BsonInt32(1234)), new BsonDocument())),
                 "tombstone event must result in Optional.empty()"
         );
@@ -60,7 +60,7 @@ public class MysqlHandlerTest {
     @DisplayName("when both key doc and value value doc are empty then null due to tombstone")
     public void testTombstoneEvent2() {
         assertEquals(Optional.empty(),
-                MYSQL_HANDLER_DEFAULT_MAPPING.handle(new SinkDocument(new BsonDocument(), new BsonDocument())),
+                RDBMS_HANDLER_DEFAULT_MAPPING.handle(new SinkDocument(new BsonDocument(), new BsonDocument())),
                 "tombstone event must result in Optional.empty()"
         );
     }
@@ -73,7 +73,7 @@ public class MysqlHandlerTest {
                         new BsonDocument("op",new BsonString("x"))
         );
         assertThrows(DataException.class, () ->
-                MYSQL_HANDLER_DEFAULT_MAPPING.handle(cdcEvent)
+                RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent)
         );
     }
 
@@ -87,7 +87,7 @@ public class MysqlHandlerTest {
                                 .append("foo",new BsonString("blah")))
         );
         assertThrows(DataException.class, () ->
-                MYSQL_HANDLER_EMPTY_MAPPING.handle(cdcEvent)
+                RDBMS_HANDLER_EMPTY_MAPPING.handle(cdcEvent)
         );
     }
 
@@ -99,7 +99,7 @@ public class MysqlHandlerTest {
                 new BsonDocument("op",new BsonInt32('c'))
         );
         assertThrows(DataException.class, () ->
-                MYSQL_HANDLER_DEFAULT_MAPPING.handle(cdcEvent)
+                RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent)
         );
     }
 
@@ -111,7 +111,7 @@ public class MysqlHandlerTest {
                 new BsonDocument("po",BsonNull.VALUE)
         );
         assertThrows(DataException.class, () ->
-                MYSQL_HANDLER_DEFAULT_MAPPING.handle(cdcEvent)
+                RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent)
         );
     }
 
@@ -122,7 +122,7 @@ public class MysqlHandlerTest {
         return Stream.of(
                 dynamicTest("test operation "+OperationType.CREATE, () -> {
                     Optional<WriteModel<BsonDocument>> result =
-                            MYSQL_HANDLER_DEFAULT_MAPPING.handle(
+                            RDBMS_HANDLER_DEFAULT_MAPPING.handle(
                                     new SinkDocument(
                                             new BsonDocument("id",new BsonInt32(1004)),
                                             new BsonDocument("op",new BsonString("c"))
@@ -137,7 +137,7 @@ public class MysqlHandlerTest {
                 }),
                 dynamicTest("test operation "+OperationType.READ, () -> {
                     Optional<WriteModel<BsonDocument>> result =
-                            MYSQL_HANDLER_DEFAULT_MAPPING.handle(
+                            RDBMS_HANDLER_DEFAULT_MAPPING.handle(
                                     new SinkDocument(
                                             new BsonDocument("id",new BsonInt32(1004)),
                                             new BsonDocument("op",new BsonString("r"))
@@ -152,7 +152,7 @@ public class MysqlHandlerTest {
                 }),
                 dynamicTest("test operation "+OperationType.UPDATE, () -> {
                     Optional<WriteModel<BsonDocument>> result =
-                            MYSQL_HANDLER_DEFAULT_MAPPING.handle(
+                            RDBMS_HANDLER_DEFAULT_MAPPING.handle(
                                     new SinkDocument(
                                             new BsonDocument("id",new BsonInt32(1004)),
                                             new BsonDocument("op",new BsonString("u"))
@@ -167,7 +167,7 @@ public class MysqlHandlerTest {
                 }),
                 dynamicTest("test operation "+OperationType.DELETE, () -> {
                     Optional<WriteModel<BsonDocument>> result =
-                            MYSQL_HANDLER_DEFAULT_MAPPING.handle(
+                            RDBMS_HANDLER_DEFAULT_MAPPING.handle(
                                     new SinkDocument(
                                             new BsonDocument("id",new BsonInt32(1004)),
                                             new BsonDocument("op",new BsonString("d"))
@@ -183,29 +183,29 @@ public class MysqlHandlerTest {
     }
 
     @TestFactory
-    @DisplayName("when valid cdc operation type then correct MySQL CdcOperation")
+    @DisplayName("when valid cdc operation type then correct RDBMS CdcOperation")
     public Stream<DynamicTest> testValidCdcOpertionTypes() {
 
         return Stream.of(
                 dynamicTest("test operation " + OperationType.CREATE, () ->
-                        assertTrue(MYSQL_HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                        assertTrue(RDBMS_HANDLER_DEFAULT_MAPPING.getCdcOperation(
                                 new BsonDocument("op", new BsonString("c")))
-                                instanceof MysqlInsert)
+                                instanceof RdbmsInsert)
                 ),
                 dynamicTest("test operation " + OperationType.READ, () ->
-                        assertTrue(MYSQL_HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                        assertTrue(RDBMS_HANDLER_DEFAULT_MAPPING.getCdcOperation(
                                 new BsonDocument("op", new BsonString("r")))
-                                instanceof MysqlInsert)
+                                instanceof RdbmsInsert)
                 ),
                 dynamicTest("test operation " + OperationType.UPDATE, () ->
-                        assertTrue(MYSQL_HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                        assertTrue(RDBMS_HANDLER_DEFAULT_MAPPING.getCdcOperation(
                                 new BsonDocument("op", new BsonString("u")))
-                                instanceof MysqlUpdate)
+                                instanceof RdbmsUpdate)
                 ),
                 dynamicTest("test operation " + OperationType.DELETE, () ->
-                        assertTrue(MYSQL_HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                        assertTrue(RDBMS_HANDLER_DEFAULT_MAPPING.getCdcOperation(
                                 new BsonDocument("op", new BsonString("d")))
-                                instanceof MysqlDelete)
+                                instanceof RdbmsDelete)
                 )
         );
 

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsInsertTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsInsertTest.java
@@ -1,4 +1,4 @@
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
 import com.mongodb.DBCollection;
@@ -14,9 +14,9 @@ import org.junit.runner.RunWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(JUnitPlatform.class)
-public class MysqlInsertTest {
+public class RdbmsInsertTest {
 
-    public static final MysqlInsert MYSQL_INSERT = new MysqlInsert();
+    public static final RdbmsInsert RDBMS_INSERT = new RdbmsInsert();
 
     @Test
     @DisplayName("when valid cdc event with single field PK then correct ReplaceOneModel")
@@ -42,7 +42,7 @@ public class MysqlInsertTest {
                         .append("email",new BsonString("annek@noanswer.org")));
 
         WriteModel<BsonDocument> result =
-                MYSQL_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof ReplaceOneModel,
                 () -> "result expected to be of type ReplaceOneModel");
@@ -89,7 +89,7 @@ public class MysqlInsertTest {
                                     .append("active", new BsonBoolean(true)));
 
         WriteModel<BsonDocument> result =
-                MYSQL_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof ReplaceOneModel,
                 () -> "result expected to be of type ReplaceOneModel");
@@ -147,7 +147,7 @@ public class MysqlInsertTest {
         BsonDocument keyDoc = new BsonDocument();
 
         WriteModel<BsonDocument> result =
-                MYSQL_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_INSERT.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof ReplaceOneModel,
                 () -> "result expected to be of type ReplaceOneModel");
@@ -183,7 +183,7 @@ public class MysqlInsertTest {
     @DisplayName("when missing key doc then DataException")
     public void testMissingKeyDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_INSERT.perform(new SinkDocument(null, new BsonDocument()))
+                RDBMS_INSERT.perform(new SinkDocument(null, new BsonDocument()))
         );
     }
 
@@ -191,7 +191,7 @@ public class MysqlInsertTest {
     @DisplayName("when missing value doc then DataException")
     public void testMissingValueDocument() {
         assertThrows(DataException.class,() ->
-            MYSQL_INSERT.perform(new SinkDocument(new BsonDocument(),null))
+            RDBMS_INSERT.perform(new SinkDocument(new BsonDocument(),null))
         );
     }
 
@@ -199,7 +199,7 @@ public class MysqlInsertTest {
     @DisplayName("when invalid json in value doc 'after' field then DataException")
     public void testInvalidAfterField() {
         assertThrows(DataException.class,() ->
-                MYSQL_INSERT.perform(
+                RDBMS_INSERT.perform(
                         new SinkDocument(new BsonDocument(),
                             new BsonDocument("op",new BsonString("c"))
                                 .append("after",new BsonString("{NO : JSON [HERE] GO : AWAY}")))

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsUpdateTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/cdc/debezium/rdbms/RdbmsUpdateTest.java
@@ -1,4 +1,4 @@
-package at.grahsl.kafka.connect.mongodb.cdc.debezium.mysql;
+package at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms;
 
 import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
 import com.mongodb.DBCollection;
@@ -14,9 +14,9 @@ import org.junit.runner.RunWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(JUnitPlatform.class)
-public class MysqlUpdateTest {
+public class RdbmsUpdateTest {
 
-    public static final MysqlUpdate MYSQL_UPDATE = new MysqlUpdate();
+    public static final RdbmsUpdate RDBMS_UPDATE = new RdbmsUpdate();
 
     @Test
     @DisplayName("when valid cdc event with single field PK then correct ReplaceOneModel")
@@ -42,7 +42,7 @@ public class MysqlUpdateTest {
                         .append("email",new BsonString("annek@noanswer.org")));
 
         WriteModel<BsonDocument> result =
-                MYSQL_UPDATE.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_UPDATE.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof ReplaceOneModel,
                 () -> "result expected to be of type ReplaceOneModel");
@@ -89,7 +89,7 @@ public class MysqlUpdateTest {
                         .append("active", new BsonBoolean(true)));
 
         WriteModel<BsonDocument> result =
-                MYSQL_UPDATE.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_UPDATE.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof ReplaceOneModel,
                 () -> "result expected to be of type ReplaceOneModel");
@@ -134,7 +134,7 @@ public class MysqlUpdateTest {
                         .append("active", new BsonBoolean(false)));
 
         WriteModel<BsonDocument> result =
-                MYSQL_UPDATE.perform(new SinkDocument(keyDoc,valueDoc));
+                RDBMS_UPDATE.perform(new SinkDocument(keyDoc,valueDoc));
 
         assertTrue(result instanceof ReplaceOneModel,
                 () -> "result expected to be of type ReplaceOneModel");
@@ -159,7 +159,7 @@ public class MysqlUpdateTest {
     @DisplayName("when missing key doc then DataException")
     public void testMissingKeyDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_UPDATE.perform(new SinkDocument(null, new BsonDocument()))
+                RDBMS_UPDATE.perform(new SinkDocument(null, new BsonDocument()))
         );
     }
 
@@ -167,7 +167,7 @@ public class MysqlUpdateTest {
     @DisplayName("when missing value doc then DataException")
     public void testMissingValueDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument(),null))
+                RDBMS_UPDATE.perform(new SinkDocument(new BsonDocument(),null))
         );
     }
 
@@ -176,7 +176,7 @@ public class MysqlUpdateTest {
     @DisplayName("when 'after' field missing in value doc then DataException")
     public void testMissingAfterFieldInValueDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                RDBMS_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
                         new BsonDocument("op",new BsonString("u"))))
         );
     }
@@ -185,7 +185,7 @@ public class MysqlUpdateTest {
     @DisplayName("when 'after' field empty in value doc then DataException")
     public void testEmptyAfterFieldInValueDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                RDBMS_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
                         new BsonDocument("op",new BsonString("u"))
                                 .append("after",new BsonDocument())))
         );
@@ -195,7 +195,7 @@ public class MysqlUpdateTest {
     @DisplayName("when 'after' field null in value doc then DataException")
     public void testNullAfterFieldInValueDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                RDBMS_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
                         new BsonDocument("op",new BsonString("u"))
                                 .append("after",new BsonNull())))
         );
@@ -205,7 +205,7 @@ public class MysqlUpdateTest {
     @DisplayName("when 'after' field no document in value doc then DataException")
     public void testNoDocumentAfterFieldInValueDocument() {
         assertThrows(DataException.class,() ->
-                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
+                RDBMS_UPDATE.perform(new SinkDocument(new BsonDocument("id",new BsonInt32(1004)),
                         new BsonDocument("op",new BsonString("u"))
                                 .append("after",new BsonString("wrong type"))))
         );
@@ -215,7 +215,7 @@ public class MysqlUpdateTest {
     @DisplayName("when key doc and value 'before' field both empty then DataException")
     public void testEmptyKeyDocAndEmptyValueBeforeField() {
         assertThrows(DataException.class,() ->
-                MYSQL_UPDATE.perform(new SinkDocument(new BsonDocument(),
+                RDBMS_UPDATE.perform(new SinkDocument(new BsonDocument(),
                         new BsonDocument("before",new BsonDocument())))
         );
     }


### PR DESCRIPTION
initial support for postgres is based on the observation that DBZ basically produces similar CDC events for mysql and postgres. thus both can for now be processed based on the same code as written for mysql. refactorings have been made to avoid redundancy and allow for specific sub-classes of RdbmsHandler should the need arise because of subtle differences in the produced CDC formats.