### PR TITLE
fix #59 DeleteOneModel behaviour for convention based deletions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>at.grahsl.kafka.connect</groupId>
     <artifactId>kafka-connect-mongodb</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>kafka-connect-mongodb</name>

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/processor/id/strategy/ProvidedStrategy.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/processor/id/strategy/ProvidedStrategy.java
@@ -52,7 +52,7 @@ public class ProvidedStrategy implements IdStrategy {
             bd = doc.getValueDoc();
         }
 
-        BsonValue _id = bd.map(vd -> vd.get(DBCollection.ID_FIELD_NAME))
+        BsonValue _id = bd.map(d -> d.get(DBCollection.ID_FIELD_NAME))
                     .orElseThrow(() -> new DataException("error: provided id strategy is used "
                         + "but the document structure either contained no _id field or it was null"));
 

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/strategy/DeleteOneDefaultStrategy.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/strategy/DeleteOneDefaultStrategy.java
@@ -1,13 +1,24 @@
 package at.grahsl.kafka.connect.mongodb.writemodel.strategy;
 
 import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import at.grahsl.kafka.connect.mongodb.processor.id.strategy.IdStrategy;
 import com.mongodb.DBCollection;
 import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.WriteModel;
 import org.apache.kafka.connect.errors.DataException;
 import org.bson.BsonDocument;
+import org.bson.BsonValue;
 
 public class DeleteOneDefaultStrategy implements WriteModelStrategy {
+
+    private IdStrategy idStrategy;
+
+    @Deprecated
+    public DeleteOneDefaultStrategy() {}
+
+    public DeleteOneDefaultStrategy(IdStrategy idStrategy) {
+        this.idStrategy = idStrategy;
+    }
 
     @Override
     public WriteModel<BsonDocument> createWriteModel(SinkDocument document) {
@@ -17,7 +28,18 @@ public class DeleteOneDefaultStrategy implements WriteModelStrategy {
                         + " the key document was missing unexpectedly")
         );
 
-        return  new DeleteOneModel<>(new BsonDocument(DBCollection.ID_FIELD_NAME, kd));
+        //NOTE: fallback for backwards / deprecation compatibility
+        if(idStrategy == null) {
+            return kd.containsKey(DBCollection.ID_FIELD_NAME)
+                    ? new DeleteOneModel<>(kd)
+                    : new DeleteOneModel<>(new BsonDocument(DBCollection.ID_FIELD_NAME,kd));
+        }
+
+        //NOTE: current design doesn't allow to access original SinkRecord (= null)
+        BsonValue _id = idStrategy.generateId(document,null);
+        return new DeleteOneModel<>(
+                new BsonDocument(DBCollection.ID_FIELD_NAME,_id)
+        );
 
     }
 }

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTaskTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTaskTest.java
@@ -3,7 +3,6 @@ package at.grahsl.kafka.connect.mongodb;
 import at.grahsl.kafka.connect.mongodb.cdc.debezium.rdbms.RdbmsHandler;
 import at.grahsl.kafka.connect.mongodb.processor.id.strategy.BsonOidStrategy;
 import at.grahsl.kafka.connect.mongodb.processor.id.strategy.FullKeyStrategy;
-import at.grahsl.kafka.connect.mongodb.processor.id.strategy.ProvidedInKeyStrategy;
 import at.grahsl.kafka.connect.mongodb.writemodel.strategy.ReplaceOneDefaultStrategy;
 import com.google.common.collect.Lists;
 import com.mongodb.DBCollection;
@@ -333,7 +332,7 @@ public class MongoDbSinkTaskTest {
 
         MongoDbSinkTask sinkTask = new MongoDbSinkTask();
         Map<String,String> props = new HashMap<>();
-        props.put(MongoDbSinkConnectorConfig.MONGODB_DOCUMENT_ID_STRATEGY_CONF,ProvidedInKeyStrategy.class.getName());
+        props.put(MongoDbSinkConnectorConfig.MONGODB_DOCUMENT_ID_STRATEGY_CONF,FullKeyStrategy.class.getName());
         props.put(MongoDbSinkConnectorConfig.MONGODB_WRITEMODEL_STRATEGY,ReplaceOneDefaultStrategy.class.getName());
         props.put(MongoDbSinkConnectorConfig.MONGODB_DELETE_ON_NULL_VALUES,"true");
         props.put("topics","foo");

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/data/avro/TweetMsg.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/data/avro/TweetMsg.java
@@ -5,6 +5,9 @@
  */
 package at.grahsl.kafka.connect.mongodb.data.avro;
 
+import org.apache.avro.message.BinaryMessageDecoder;
+import org.apache.avro.message.BinaryMessageEncoder;
+import org.apache.avro.message.SchemaStore;
 import org.apache.avro.specific.SpecificData;
 
 @SuppressWarnings("all")
@@ -13,6 +16,41 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
   private static final long serialVersionUID = -614364705592652792L;
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"TweetMsg\",\"namespace\":\"at.grahsl.kafka.connect.mongodb.data.avro\",\"fields\":[{\"name\":\"_id\",\"type\":\"long\"},{\"name\":\"text\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}},{\"name\":\"hashtags\",\"type\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"avro.java.string\":\"String\"}}}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
+
+  private static SpecificData MODEL$ = new SpecificData();
+
+  private static final BinaryMessageEncoder<TweetMsg> ENCODER =
+      new BinaryMessageEncoder<TweetMsg>(MODEL$, SCHEMA$);
+
+  private static final BinaryMessageDecoder<TweetMsg> DECODER =
+      new BinaryMessageDecoder<TweetMsg>(MODEL$, SCHEMA$);
+
+  /**
+   * Return the BinaryMessageDecoder instance used by this class.
+   */
+  public static BinaryMessageDecoder<TweetMsg> getDecoder() {
+    return DECODER;
+  }
+
+  /**
+   * Create a new BinaryMessageDecoder instance for this class that uses the specified {@link SchemaStore}.
+   * @param resolver a {@link SchemaStore} used to find schemas by fingerprint
+   */
+  public static BinaryMessageDecoder<TweetMsg> createDecoder(SchemaStore resolver) {
+    return new BinaryMessageDecoder<TweetMsg>(MODEL$, SCHEMA$, resolver);
+  }
+
+  /** Serializes this TweetMsg to a ByteBuffer. */
+  public java.nio.ByteBuffer toByteBuffer() throws java.io.IOException {
+    return ENCODER.encode(this);
+  }
+
+  /** Deserializes a TweetMsg from a ByteBuffer. */
+  public static TweetMsg fromByteBuffer(
+      java.nio.ByteBuffer b) throws java.io.IOException {
+    return DECODER.decode(b);
+  }
+
    private long _id;
    private java.lang.String text;
    private java.util.List<java.lang.String> hashtags;
@@ -304,6 +342,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public TweetMsg build() {
       try {
         TweetMsg record = new TweetMsg();
@@ -311,22 +350,24 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
         record.text = fieldSetFlags()[1] ? this.text : (java.lang.String) defaultValue(fields()[1]);
         record.hashtags = fieldSetFlags()[2] ? this.hashtags : (java.util.List<java.lang.String>) defaultValue(fields()[2]);
         return record;
-      } catch (Exception e) {
+      } catch (java.lang.Exception e) {
         throw new org.apache.avro.AvroRuntimeException(e);
       }
     }
   }
 
-  private static final org.apache.avro.io.DatumWriter
-    WRITER$ = new org.apache.avro.specific.SpecificDatumWriter(SCHEMA$);
+  @SuppressWarnings("unchecked")
+  private static final org.apache.avro.io.DatumWriter<TweetMsg>
+    WRITER$ = (org.apache.avro.io.DatumWriter<TweetMsg>)MODEL$.createDatumWriter(SCHEMA$);
 
   @Override public void writeExternal(java.io.ObjectOutput out)
     throws java.io.IOException {
     WRITER$.write(this, SpecificData.getEncoder(out));
   }
 
-  private static final org.apache.avro.io.DatumReader
-    READER$ = new org.apache.avro.specific.SpecificDatumReader(SCHEMA$);
+  @SuppressWarnings("unchecked")
+  private static final org.apache.avro.io.DatumReader<TweetMsg>
+    READER$ = (org.apache.avro.io.DatumReader<TweetMsg>)MODEL$.createDatumReader(SCHEMA$);
 
   @Override public void readExternal(java.io.ObjectInput in)
     throws java.io.IOException {


### PR DESCRIPTION
Before only a few specific use cases were supported. Besides the fix this improvement allows
for a few more scenarios:
- takes into account the configured DocumentIdAdder IdStrategy
- is collection-aware so that different configuration per topic/collection are possible