### PR TITLE
implements feature #67 to have fallback topic name support

### DIFF
--- a/config/MongoDbSinkConnector.properties
+++ b/config/MongoDbSinkConnector.properties
@@ -28,7 +28,7 @@ connector.class=at.grahsl.kafka.connect.mongodb.MongoDbSinkConnector
 #specific MongoDB sink connector props
 #listed below are the defaults
 mongodb.connection.uri=mongodb://localhost:27017/kafkaconnect?w=1&journal=true
-mongodb.collection=kafkatopic
+mongodb.collection=
 mongodb.max.num.retries=3
 mongodb.retries.defer.timeout=5000
 mongodb.value.projection.type=none

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>at.grahsl.kafka.connect</groupId>
     <artifactId>kafka-connect-mongodb</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>kafka-connect-mongodb</name>

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
@@ -64,7 +64,7 @@ public class MongoDbSinkConnectorConfig extends CollectionAwareConfig {
 
     public static final String MONGODB_CONNECTION_URI_DEFAULT = "mongodb://localhost:27017/kafkaconnect?w=1&journal=true";
     public static final String MONGODB_COLLECTIONS_DEFAULT = "";
-    public static final String MONGODB_COLLECTION_DEFAULT = "kafkatopic";
+    public static final String MONGODB_COLLECTION_DEFAULT = "";
     public static final int MONGODB_MAX_NUM_RETRIES_DEFAULT = 3;
     public static final int MONGODB_RETRIES_DEFER_TIMEOUT_DEFAULT = 5000;
     public static final String MONGODB_VALUE_PROJECTION_TYPE_DEFAULT = "none";

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTask.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTask.java
@@ -156,6 +156,12 @@ public class MongoDbSinkTask extends SinkTask {
         LOGGER.debug("buffering sink records into grouped topic batches");
         records.forEach(r -> {
             String collection = sinkConfig.getString(MongoDbSinkConnectorConfig.MONGODB_COLLECTION_CONF,r.topic());
+            if(collection.isEmpty()) {
+                LOGGER.debug("no explicit collection name mapping found for topic {} "
+                        + "and default collection name was empty ",r.topic());
+                LOGGER.debug("using topic name {} as collection name",r.topic());
+                collection = r.topic();
+            }
             String namespace = database.getName()+"."+collection;
             MongoCollection<BsonDocument> mongoCollection = cachedCollections.get(namespace);
             if(mongoCollection == null) {


### PR DESCRIPTION
for very simple pass-through kinds of streaming ETL pipelines from kafka to mongodb it is now possible to fallback to the name of the kafka topic which is taken as is to name the corresponding mongodb collection.

the behaviour is applied iff the **"default" collection name is set to an empty string** in the configuration

```properties
mongodb.collection=
```

whenever the sink connector doesn't find an explicit mapping for a kafka topic it then just uses the kafka topic name instead to fallback to the otherwise configured default mongodb collection name.

solves #67
