### PR TITLE
Ensuring order of bulk operations to avoid data loss or inconistent

### DIFF
--- a/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTask.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkTask.java
@@ -51,7 +51,7 @@ public class MongoDbSinkTask extends SinkTask {
     private static Logger LOGGER = LoggerFactory.getLogger(MongoDbSinkTask.class);
 
     private static final BulkWriteOptions BULK_WRITE_OPTIONS =
-                            new BulkWriteOptions().ordered(false);
+                            new BulkWriteOptions().ordered(true);
 
     private MongoDbSinkConnectorConfig sinkConfig;
     private MongoClient mongoClient;


### PR DESCRIPTION
Solving this issue: https://github.com/hpgrahsl/kafka-connect-mongodb/issues/98