### PR TITLE
fix broken travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 env:
-  DOCKER_COMPOSE_VERSION: 1.11.2
+  DOCKER_COMPOSE_VERSION=1.11.2
 
 addons:
   hosts:
@@ -17,7 +17,8 @@ addons:
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 env:
-  DOCKER_COMPOSE_VERSION=1.11.2
+  DOCKER_COMPOSE_VERSION=1.25.0
 
 addons:
   hosts:


### PR DESCRIPTION
oraclejdk8 not longer supported it seems thus switching to openjdk. running builds with version 8 + 11 for now