### PR TITLE
Use HTTPS for repository access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
Hi @hpgrahsl, since Maven 3.8.1, the default behavior is to block HTTP access and prefer HTTPS access for repositories.  The `kstreams` example in the Debezium examples repository is based on this code and fails to build due to this.  Could we consider applying this small change to this repository and re-tagging?

In the meantime, I am going to modify the pom in our example build steps to circumvent this for now.